### PR TITLE
Add network drive security groups and access configuration

### DIFF
--- a/network_drives/security/network_drive_security.xml
+++ b/network_drives/security/network_drive_security.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+        <!-- Network Drive User Group -->
+        <record id="group_network_drive_user" model="res.groups">
+            <field name="name">Network Drive User</field>
+            <field name="category_id" ref="base.module_category_tools"/>
+            <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
+        </record>
+
+        <!-- Network Drive Manager Group -->
+        <record id="group_network_drive_manager" model="res.groups">
+            <field name="name">Network Drive Manager</field>
+            <field name="category_id" ref="base.module_category_tools"/>
+            <field name="implied_ids" eval="[(4, ref('group_network_drive_user'))]"/>
+            <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
This PR adds security configuration for network drives by implementing user groups and access controls. Changes include:

- Created new security groups file `network_drive_security.xml`
- Added two security groups:
  - Network Drive User: basic access for regular users
  - Network Drive Manager: advanced access with administrative privileges
- Updated `__manifest__.py` to include the new security configuration file
- Set default admin users for manager group

The security groups will help manage access control for network drive functionality across the application.