### PR TITLE
Simplify VPN management and improve security model

### DIFF
--- a/network_drives/data/vpn_actions.xml
+++ b/network_drives/data/vpn_actions.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data>
-        <record id="ir_cron_monitor_vpn_connections" model="ir.cron">
-            <field name="name">Monitor VPN Connections</field>
-            <field name="model_id" ref="model_vpn_connection"/>
-            <field name="state">code</field>
-            <field name="code">model._monitor_vpn_connections()</field>
-            <field name="interval_number">5</field>
-            <field name="interval_type">minutes</field>
-            <field name="numbercall">-1</field>
-            <field name="active">True</field>
-        </record>
-    </data>
+    <record id="action_vpn_credential" model="ir.actions.act_window">
+        <field name="name">VPN Credentials</field>
+        <field name="res_model">vpn.credential</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <record id="action_vpn_connection" model="ir.actions.act_window">
+        <field name="name">VPN Connections</field>
+        <field name="res_model">vpn.connection</field>
+        <field name="view_mode">tree,form</field>
+    </record>
 </odoo>

--- a/network_drives/models/vpn_credential.py
+++ b/network_drives/models/vpn_credential.py
@@ -1,47 +1,12 @@
-from odoo import models, fields, api
-from odoo.exceptions import UserError
-import logging
-
-_logger = logging.getLogger(__name__)
+from odoo import models, fields
 
 class VPNCredential(models.Model):
     _name = 'vpn.credential'
     _description = 'VPN Credentials'
 
-    name = fields.Char(string='Name', required=True)
-    vpn_type = fields.Selection([
-        ('sonicwall', 'SonicWall NetExtender'),
-        ('cisco', 'Cisco AnyConnect'),
-        # Add other VPN types as needed
-    ], string='VPN Type', required=True)
-
-    server = fields.Char(string='Server', required=True)
-    port = fields.Integer(string='Port', default=4433)
-    domain = fields.Char(string='Domain')
-    username = fields.Char(string='Username', required=True)
-    password = fields.Char(string='Password', required=True)
-
-    # For security, store password encrypted
-    password_encrypted = fields.Char(string='Encrypted Password', readonly=True)
-
-    active = fields.Boolean(default=True)
-    state = fields.Selection([
-        ('disconnected', 'Disconnected'),
-        ('connected', 'Connected'),
-        ('error', 'Error')
-    ], default='disconnected', string='Status')
-
-    last_connection = fields.Datetime(string='Last Connection')
-    last_error = fields.Text(string='Last Error')
-
-    @api.model
-    def create(self, vals):
-        # Encrypt password before storing
-        if vals.get('password'):
-            vals['password_encrypted'] = self._encrypt_password(vals['password'])
-            vals['password'] = '********'  # Don't store plain password
-        return super(VPNCredential, self).create(vals)
-
-    def _encrypt_password(self, password):
-        # Implement proper encryption here
-        return password  # Placeholder
+    name = fields.Char(required=True)
+    server = fields.Char(required=True)
+    port = fields.Integer(default=4433)
+    domain = fields.Char(required=True)
+    username = fields.Char(required=True)
+    password = fields.Char(required=True)

--- a/network_drives/security/ir.model.access.csv
+++ b/network_drives/security/ir.model.access.csv
@@ -6,7 +6,7 @@ access_network_drive_content_admin,network.drive.content.admin,model_network_dri
 access_driver_credential_admin,network.driver.credential,model_driver_credential,base.group_system,1,1,1,1
 access_driver_credential_user,driver.credential.user,model_driver_credential,base.group_user,1,0,0,0
 
-access_vpn_credential_admin,vpn.credential.admin,model_vpn_credential,base.group_system,1,1,1,1
-access_vpn_credential_user,vpn.credential.user,model_vpn_credential,base.group_user,1,1,1,1
-access_vpn_connection_admin,vpn.connection.admin,model_vpn_connection,base.group_system,1,1,1,1
-access_vpn_connection_user,vpn.connection.user,model_vpn_connection,base.group_user,1,1,1,1
+access_vpn_credential_user,vpn.credential user,model_vpn_credential,base.group_user,1,0,0,0
+access_vpn_credential_manager,vpn.credential manager,model_vpn_credential,base.group_system,1,1,1,1
+access_vpn_connection_user,vpn.connection user,model_vpn_connection,base.group_user,1,0,0,0
+access_vpn_connection_manager,vpn.connection manager,model_vpn_connection,base.group_system,1,1,1,1

--- a/network_drives/views/vpn_views.xml
+++ b/network_drives/views/vpn_views.xml
@@ -1,5 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <record id="view_vpn_credential_form" model="ir.ui.view">
+        <field name="name">vpn.credential.form</field>
+        <field name="model">vpn.credential</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="server"/>
+                        <field name="port"/>
+                        <field name="domain"/>
+                        <field name="username"/>
+                        <field name="password" password="True"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
     <record id="view_vpn_connection_form" model="ir.ui.view">
         <field name="name">vpn.connection.form</field>
         <field name="model">vpn.connection</field>
@@ -8,18 +27,13 @@
                 <header>
                     <button name="connect" string="Connect" type="object" class="oe_highlight"/>
                     <button name="disconnect" string="Disconnect" type="object"/>
-                    <field name="status" widget="statusbar"/>
                 </header>
                 <sheet>
                     <group>
                         <field name="name"/>
-                        <field name="server"/>
-                        <field name="domain"/>
-                        <field name="username"/>
-                        <field name="password" password="True"/>
-                        <field name="vpn_type"/>
-                        <field name="auto_reconnect"/>
-                        <field name="last_check_time" readonly="1"/>
+                        <field name="credential_id"/>
+                        <field name="status"/>
+                        <field name="last_error"/>
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
This PR simplifies the VPN management system and improves the security model. Key changes include:

- Separated VPN credentials from connections for better security
- Simplified VPN credential model to focus on essential fields
- Updated access rights to restrict user permissions (read-only for users, full access for managers)
- Replaced complex connection monitoring with simple connect/disconnect functionality
- Added dedicated views and actions for both credentials and connections
- Implemented basic VPN manager with NetExtender support
- Added error logging for connection failures

Security improvements:
- Users can only view VPN settings
- System managers have full CRUD access
- Credentials are managed separately from connection status

Breaking changes:
- Removed auto-reconnect functionality
- Removed VPN type selection (now focused on NetExtender)
- Removed connection monitoring cron job