### PR TITLE
Add VPN Configuration Support for Network Drives

### DIFF
--- a/network_drives/__manifest__.py
+++ b/network_drives/__manifest__.py
@@ -9,6 +9,7 @@
     'data': [
         'views/network_drive_views.xml',
         'views/driver_credential_views.xml',
+        'views/vpn_configuration_views.xml',
         'security/ir.model.access.csv',
     ],
     "external_dependencies": {"python": [

--- a/network_drives/models/__init__.py
+++ b/network_drives/models/__init__.py
@@ -1,2 +1,3 @@
 from . import network_drive
 from . import driver_credential
+from . import vpn_configuration

--- a/network_drives/models/network_drive.py
+++ b/network_drives/models/network_drive.py
@@ -1,4 +1,5 @@
 from odoo import models, fields, api
+from odoo import fields
 import os
 import zipfile
 import io
@@ -52,6 +53,8 @@ class NetworkDrive(models.Model):
         return super(NetworkDrive, self).write(vals)
 
     def _connect_to_share(self):
+        if self.require_vpn:
+            self._ensure_vpn_connected()
         """Internal method to establish connection"""
         for record in self:
             _logger.info("Start _connect_to_share%s:", self.name)
@@ -124,6 +127,13 @@ class NetworkDriveContent(models.Model):
     path = fields.Char(string='Path', required=False)
     item_type = fields.Selection([('File', 'File'), ('Folder', 'Folder')], string='Type', required=False)
     drive_id = fields.Many2one('network.drive', string='Drive', required=True, ondelete='cascade')
+    vpn_configuration_id = fields.Many2one('vpn.configuration', string='VPN Configuration')
+    require_vpn = fields.Boolean(default=False)
+
+    def _ensure_vpn_connected(self):
+        if self.require_vpn and self.vpn_configuration_id:
+            # Add VPN connection logic here
+            pass
     parent_id = fields.Many2one('network.drive.content', string='Parent', index=True, ondelete='cascade')
     child_ids = fields.One2many('network.drive.content', 'parent_id', string='Children')
     parent_path = fields.Char(index=True)

--- a/network_drives/models/vpn_configuration.py
+++ b/network_drives/models/vpn_configuration.py
@@ -1,0 +1,15 @@
+from odoo import models, fields, api
+
+class VpnConfiguration(models.Model):
+    _name = 'vpn.configuration'
+    _description = 'VPN Configuration'
+
+    name = fields.Char(required=True)
+    server = fields.Char(required=True)
+    port = fields.Integer(default=4433)
+    domain = fields.Char()
+    username = fields.Char(required=True)
+    password = fields.Char(required=True)
+    vpn_type = fields.Selection([
+        ('sonicwall', 'SonicWall NetExtender')
+    ], default='sonicwall', required=True)

--- a/network_drives/security/ir.model.access.csv
+++ b/network_drives/security/ir.model.access.csv
@@ -5,3 +5,5 @@ access_network_drive_content_user,network.drive.content.user,model_network_drive
 access_network_drive_content_admin,network.drive.content.admin,model_network_drive_content,base.group_system,1,1,1,1
 access_driver_credential_admin,network.driver.credential,model_driver_credential,base.group_system,1,1,1,1
 access_driver_credential_user,driver.credential.user,model_driver_credential,base.group_user,1,0,0,0
+access_vpn_configuration_user,vpn.configuration.user,model_vpn_configuration,base.group_user,1,0,0,0
+access_vpn_configuration_manager,vpn.configuration.manager,model_vpn_configuration,base.group_system,1,1,1,1

--- a/network_drives/views/network_drive_views.xml
+++ b/network_drives/views/network_drive_views.xml
@@ -27,6 +27,10 @@
                     <group attrs="{'invisible': [('is_networkdrive', '!=', True)]}">
                         <field name="driver_credential_id" attrs="{'required': [('is_networkdrive', '=', True)]}"/>
                     </group>
+                    <group>
+                        <field name="require_vpn"/>
+                        <field name="vpn_configuration_id" attrs="{'required': [('require_vpn', '=', True)]}"/>
+                    </group>
                     <div class="oe_button_box" name="button_box">
                         <button name="action_refresh_contents" type="object" class="oe_stat_button" icon="fa-refresh">
                             Refresh Contents

--- a/network_drives/views/vpn_configuration_views.xml
+++ b/network_drives/views/vpn_configuration_views.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_vpn_configuration_form" model="ir.ui.view">
+        <field name="name">vpn.configuration.form</field>
+        <field name="model">vpn.configuration</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="vpn_type"/>
+                        <field name="server"/>
+                        <field name="port"/>
+                        <field name="domain"/>
+                        <field name="username"/>
+                        <field name="password" password="True"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_vpn_configuration" model="ir.actions.act_window">
+        <field name="name">VPN Configurations</field>
+        <field name="res_model">vpn.configuration</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_vpn_configuration"
+              name="VPN Configurations"
+              parent="menu_network_drives_configuration"
+              action="action_vpn_configuration"
+              sequence="20"/>
+</odoo>


### PR DESCRIPTION
This PR adds VPN configuration support for network drives. The changes include:

- New `vpn.configuration` model for storing VPN connection details
- Integration with network drives through `require_vpn` and `vpn_configuration_id` fields
- New VPN Configurations menu item under Network Drives configuration
- Security access rules for VPN configuration management
- Form views and UI elements for VPN configuration
- Placeholder for VPN connection logic in `_ensure_vpn_connected` method

Currently supports SonicWall NetExtender VPN type with the following configuration options:
- Server address
- Port (default: 4433)
- Domain
- Username/Password
- Connection type selection

Access rights:
- Regular users can view VPN configurations
- System administrators can create/edit/delete VPN configurations