### PR TITLE
Add Open Drive button to network drives list view

### DIFF
--- a/network_drives/models/network_drive.py
+++ b/network_drives/models/network_drive.py
@@ -69,6 +69,20 @@ class NetworkDrive(models.Model):
                 _logger.info(f"Not Connected : {str(e)}")
                 # raise UserWarning(f"Connection failed: {str(e)}")
 
+    def action_open_drive(self):
+        """Open the network drive path in a new tab"""
+        if self.file_path:
+            if self.is_networkdrive:
+                self._connect_to_share()
+            path = self.file_path.replace('file:///', '')
+            if os.path.exists(path):
+                return {
+                    'type': 'ir.actions.act_url',
+                    'url': f"/folder/open/?path={path}",
+                    'target': 'new',
+                }
+        return False
+
     def action_refresh_contents(self):
         _logger.info(f"Refreshing contents for drive: {self.name}")
         self.content_ids.unlink()  # Clear existing contents

--- a/network_drives/views/network_drive_views.xml
+++ b/network_drives/views/network_drive_views.xml
@@ -8,6 +8,10 @@
             <tree string="Network Drives">
                 <field name="name"/>
                 <field name="file_path"/>
+                <button name="action_open_drive" 
+                        type="object" 
+                        string="Open" 
+                        icon="fa-external-link"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
This PR adds functionality to open network drives directly from the list view. Changes include:

- Added `action_open_drive()` method to NetworkDrive model that:
  - Handles network drive connections if needed
  - Opens the drive path in a new tab
  - Returns False if path doesn't exist
- Added "Open" button to network drives tree view with external link icon
- Button triggers the new action_open_drive method

The changes improve user experience by providing quick access to network drives directly from the Odoo interface.