### PR TITLE
Add network path opening functionality to NetworkDrive

### DIFF
--- a/network_drives/views/network_drive_views.xml
+++ b/network_drives/views/network_drive_views.xml
@@ -8,6 +8,11 @@
             <tree string="Network Drives">
                 <field name="name"/>
                 <field name="file_path"/>
+                <button name="action_open_network_path"
+                        type="object"
+                        string="Open"
+                        icon="fa-external-link"
+                        class="btn-secondary"/>
             </tree>
         </field>
     </record>
@@ -26,6 +31,12 @@
                                 class="oe_stat_button"
                                 icon="fa-refresh">
                             Refresh Contents
+                        </button>
+                        <button name="action_open_network_path"
+                                type="object"
+                                class="oe_stat_button"
+                                icon="fa-external-link">
+                            Open Path
                         </button>
                     </div>
 


### PR DESCRIPTION
This PR adds functionality to open network paths directly from the UI. Changes include:

- Added new `action_open_network_path` method to NetworkDrive model
- Added UserWarning import for error handling
- Updated tree view to include "Open" button with external link icon
- Added "Open Path" button to form view button box
- Added proper path cleaning and formatting for Windows network paths
- Implemented error handling with logging

The new functionality allows users to:
- Open network paths directly from the list view using a quick access button
- Access network paths from the form view using the new stat button
- Receive proper error messages if path opening fails