### PR TITLE
Change UserWarning to UserError for better error handling

### DIFF
--- a/network_drives/models/network_drive.py
+++ b/network_drives/models/network_drive.py
@@ -6,7 +6,7 @@ import logging
 from odoo.http import request
 import win32wnet
 import win32netcon
-from odoo.exceptions import UserWarning
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
@@ -76,7 +76,7 @@ class NetworkDrive(models.Model):
             }
         except Exception as e:
             _logger.error(f"Failed to open network path: {str(e)}")
-            raise UserWarning(f"Failed to open network path: {str(e)}")
+            raise UserError(f"Failed to open network path: {str(e)}")
 
     def _connect_to_share(self):
         """Internal method to establish connection"""


### PR DESCRIPTION
This PR updates the error handling in the network drive module by replacing `UserWarning` with `UserError`. Changes include:

- Changed import from `UserWarning` to `UserError` in network_drive.py
- Updated error handling in `action_open_network_path` method to raise `UserError` instead of `UserWarning`

This change provides better error handling as `UserError` is the standard Odoo exception for user-facing errors, while `UserWarning` is typically used for warnings that don't interrupt execution.